### PR TITLE
refactor: num_rows & sync block reader cache

### DIFF
--- a/src/query/storages/common/cache/src/lib.rs
+++ b/src/query/storages/common/cache/src/lib.rs
@@ -40,5 +40,6 @@ pub use read::InMemoryBytesCacheReader;
 pub use read::InMemoryItemCacheReader;
 pub use read::LoadParams;
 pub use read::Loader;
+pub use read::SyncLoader;
 
 pub use self::metrics::*;

--- a/src/query/storages/common/cache/src/read/loader.rs
+++ b/src/query/storages/common/cache/src/read/loader.rs
@@ -34,3 +34,13 @@ pub trait Loader<T> {
         params.location.clone()
     }
 }
+
+pub trait SyncLoader<T> {
+    /// Loads object of type T, located by [params][LoadParams].
+    fn sync_load(&self, params: &LoadParams) -> Result<T>;
+
+    /// the [CacheKey] returns will be used as the key of cached item.
+    fn cache_key(&self, params: &LoadParams) -> CacheKey {
+        params.location.clone()
+    }
+}

--- a/src/query/storages/common/cache/src/read/mod.rs
+++ b/src/query/storages/common/cache/src/read/mod.rs
@@ -21,5 +21,6 @@ pub use cached_reader::CachedReader;
 pub use loader::CacheKey;
 pub use loader::LoadParams;
 pub use loader::Loader;
+pub use loader::SyncLoader;
 pub use readers::InMemoryBytesCacheReader;
 pub use readers::InMemoryItemCacheReader;

--- a/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
+++ b/src/query/storages/fuse/src/io/read/block/block_reader_parquet_deserialize.rs
@@ -35,7 +35,6 @@ use storages_common_cache::TableDataCacheKey;
 use storages_common_cache_manager::CacheManager;
 use storages_common_table_meta::meta::ColumnMeta;
 use storages_common_table_meta::meta::Compression;
-use storages_common_table_meta::meta::Location;
 
 use super::block_reader_deserialize::DeserializedArray;
 use super::block_reader_deserialize::FieldDeserializationContext;
@@ -43,7 +42,6 @@ use crate::fuse_part::FusePartInfo;
 use crate::io::read::block::block_reader_merge_io::DataItem;
 use crate::io::read::block::decompressor::BuffedBasicDecompressor;
 use crate::io::BlockReader;
-use crate::io::DeleteMarkReader;
 use crate::io::UncompressedBuffer;
 use crate::metrics::*;
 
@@ -170,23 +168,6 @@ impl BlockReader {
             }
         }
         data_block
-    }
-
-    pub async fn apply_deletion_mask(
-        &self,
-        data_block: DataBlock,
-        deletion_mark: &Option<(Location, u64)>,
-        num_rows: usize,
-    ) -> Result<DataBlock> {
-        // apply deletion mask if necessary
-        if let Some((delete_marker_location, meta_size)) = deletion_mark {
-            let mask = delete_marker_location
-                .read_delete_mark(self.operator.clone(), *meta_size, num_rows)
-                .await?;
-            data_block.filter_with_bitmap(mask.as_ref())
-        } else {
-            Ok(data_block)
-        }
     }
 
     fn chunks_to_parquet_array_iter<'a>(

--- a/src/query/storages/fuse/src/io/read/delete/delete_mark_reader.rs
+++ b/src/query/storages/fuse/src/io/read/delete/delete_mark_reader.rs
@@ -19,195 +19,66 @@ use common_arrow::arrow::datatypes::DataType;
 use common_arrow::arrow::datatypes::Field as ArrowField;
 use common_arrow::arrow::io::parquet::read::column_iter_to_arrays;
 use common_arrow::parquet::compression::Compression;
-use common_arrow::parquet::metadata::ColumnChunkMetaData;
 use common_arrow::parquet::metadata::ColumnDescriptor;
 use common_arrow::parquet::read::BasicDecompressor;
 use common_arrow::parquet::read::PageMetaData;
 use common_arrow::parquet::read::PageReader;
-use common_base::runtime::GlobalIORuntime;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_expression::types::BooleanType;
 use common_expression::types::ValueType;
 use common_expression::Column;
 use opendal::Operator;
-use storages_common_cache::CacheKey;
-use storages_common_cache::InMemoryItemCacheReader;
-use storages_common_cache::LoadParams;
-use storages_common_cache::Loader;
-use storages_common_cache_manager::CachedObject;
-use storages_common_cache_manager::DeleteMarkMeta;
-use storages_common_table_meta::meta::DeleteMaskVersion;
-use storages_common_table_meta::meta::Location;
-
-use crate::io::read::InRuntime;
-use crate::io::MetaReaders;
-
-type CachedReader = InMemoryItemCacheReader<Bitmap, DeleteMetaLoader>;
 
 #[async_trait::async_trait]
 pub trait DeleteMarkReader {
     async fn read_delete_mark(&self, dal: Operator, size: u64) -> Result<Arc<Bitmap>>;
 }
 
-#[async_trait::async_trait]
-impl DeleteMarkReader for Location {
-    async fn read_delete_mark(&self, dal: Operator, size: u64) -> Result<Arc<Bitmap>> {
-        let (path, ver) = &self;
-        let mask_version = DeleteMaskVersion::try_from(*ver)?;
-        if matches!(mask_version, DeleteMaskVersion::V0(_)) {
-            let res = load_delete_mark(dal, path, size).await?;
-            Ok(res)
-        } else {
-            unreachable!()
-        }
-    }
-}
-
-/// load delete mark data
-#[tracing::instrument(level = "debug", skip_all)]
-pub async fn load_delete_mark(dal: Operator, path: &str, size: u64) -> Result<Arc<Bitmap>> {
-    // 1. load delete mark meta
-    let delete_mark_meta = load_mark_meta(dal.clone(), path, size).await?;
-    let file_meta = &delete_mark_meta.0;
-    if file_meta.row_groups.len() != 1 {
-        return Err(ErrorCode::StorageOther(format!(
-            "invalid delete mark meta, number of row group should be 1, but found {} row groups",
-            file_meta.row_groups.len()
-        )));
-    }
-
-    // 2. load delete mark data
-    let index_column_chunk_metas = file_meta.row_groups[0].columns();
-    assert_eq!(index_column_chunk_metas.len(), 1);
-    let column_meta = &index_column_chunk_metas[0];
-    let num_rows = column_meta.num_values();
-    let marks = load_delete_mark_data(column_meta, path, &dal, num_rows as usize).await?;
-
-    Ok(marks)
-}
-
-/// read data from cache, or populate cache items if possible
-#[tracing::instrument(level = "debug", skip_all)]
-async fn load_delete_mark_data<'a>(
-    col_chunk_meta: &'a ColumnChunkMetaData,
-    path: &'a str,
-    dal: &'a Operator,
+pub(super) fn deserialize_bitmap(
+    bytes: &[u8],
     num_rows: usize,
-) -> Result<Arc<Bitmap>> {
-    let storage_runtime = GlobalIORuntime::instance();
-    let bytes = {
-        let meta = col_chunk_meta.metadata();
-        let location = path.to_string();
-        let loader = DeleteMetaLoader {
-            num_rows,
-            offset: meta.data_page_offset as u64,
-            len: meta.total_compressed_size as u64,
-            cache_key: location.clone(),
-            operator: dal.clone(),
-            column_descriptor: col_chunk_meta.descriptor().clone(),
-        };
+    column_descriptor: &ColumnDescriptor,
+) -> Result<Bitmap> {
+    let descriptor = column_descriptor.descriptor.clone();
+    let page_meta_data = PageMetaData {
+        column_start: 0,
+        num_values: num_rows as i64,
+        compression: Compression::Uncompressed,
+        descriptor,
+    };
 
-        let cached_reader = CachedReader::new(Bitmap::cache(), loader);
+    let page_reader = PageReader::new_with_page_meta(
+        std::io::Cursor::new(bytes), // we can not use &[u8] as Reader here, lifetime not valid
+        page_meta_data,
+        Arc::new(|_, _| true),
+        vec![],
+        usize::MAX,
+    );
 
-        let param = LoadParams {
-            location,
-            len_hint: None,
-            ver: 0,
-        };
-        async move { cached_reader.read(&param).await }
-    }
-    .execute_in_runtime(&storage_runtime)
-    .await??;
-    Ok(bytes)
-}
+    let decompressor = BasicDecompressor::new(page_reader, vec![]);
+    let column_type = column_descriptor.descriptor.primitive_type.clone();
+    let filed_name = column_descriptor.path_in_schema[0].to_owned();
+    let field = ArrowField::new(filed_name, DataType::Boolean, false);
+    let mut array_iter = column_iter_to_arrays(
+        vec![decompressor],
+        vec![&column_type],
+        field,
+        None,
+        num_rows,
+    )?;
+    if let Some(array) = array_iter.next() {
+        let array = array?;
+        let col = Column::from_arrow(array.as_ref(), &common_expression::types::DataType::Boolean);
 
-/// Loads index meta data
-/// read data from cache, or populate cache items if possible
-#[tracing::instrument(level = "debug", skip_all)]
-async fn load_mark_meta(dal: Operator, path: &str, size: u64) -> Result<Arc<DeleteMarkMeta>> {
-    let path_owned = path.to_owned();
-    async move {
-        let reader = MetaReaders::delete_mark_meta_reader(dal);
-        // Format of FileMetaData is not versioned, version argument is ignored by the underlying reader,
-        // so we just pass a zero to reader
-        let version = 0;
+        let bitmap = BooleanType::try_downcast_column(&col).ok_or_else(|| {
+            ErrorCode::Internal("unexpected exception: load delete mark raw data as boolean failed")
+        })?;
 
-        let load_params = LoadParams {
-            location: path_owned,
-            len_hint: Some(size),
-            ver: version,
-        };
-
-        reader.read(&load_params).await
-    }
-    .execute_in_runtime(&GlobalIORuntime::instance())
-    .await?
-}
-
-pub struct DeleteMetaLoader {
-    pub num_rows: usize,
-    pub offset: u64,
-    pub len: u64,
-    pub cache_key: String,
-    pub operator: Operator,
-    pub column_descriptor: ColumnDescriptor,
-}
-
-#[async_trait::async_trait]
-impl Loader<Bitmap> for DeleteMetaLoader {
-    async fn load(&self, params: &LoadParams) -> Result<Bitmap> {
-        let reader = self.operator.object(&params.location);
-        let bytes = reader
-            .range_read(self.offset..self.offset + self.len)
-            .await?;
-
-        let page_meta_data = PageMetaData {
-            column_start: 0,
-            num_values: self.num_rows as i64,
-            compression: Compression::Uncompressed,
-            descriptor: self.column_descriptor.descriptor.clone(),
-        };
-
-        let page_reader = PageReader::new_with_page_meta(
-            std::io::Cursor::new(bytes), /* we can not use &[u8] as Reader here, lifetime not valid */
-            page_meta_data,
-            Arc::new(|_, _| true),
-            vec![],
-            usize::MAX,
-        );
-
-        let decompressor = BasicDecompressor::new(page_reader, vec![]);
-        let column_type = self.column_descriptor.descriptor.primitive_type.clone();
-        let filed_name = self.column_descriptor.path_in_schema[0].to_owned();
-        let field = ArrowField::new(filed_name, DataType::Boolean, false);
-        let mut array_iter = column_iter_to_arrays(
-            vec![decompressor],
-            vec![&column_type],
-            field,
-            None,
-            self.num_rows,
-        )?;
-        if let Some(array) = array_iter.next() {
-            let array = array?;
-            let col =
-                Column::from_arrow(array.as_ref(), &common_expression::types::DataType::Boolean);
-
-            let bitmap = BooleanType::try_downcast_column(&col).ok_or_else(|| {
-                ErrorCode::Internal(
-                    "unexpected exception: load delete mark raw data as boolean failed",
-                )
-            })?;
-
-            Ok(bitmap)
-        } else {
-            Err(ErrorCode::StorageOther(
-                "delete mark data not available as expected",
-            ))
-        }
-    }
-
-    fn cache_key(&self, _params: &LoadParams) -> CacheKey {
-        self.cache_key.clone()
+        Ok(bitmap)
+    } else {
+        Err(ErrorCode::StorageOther(
+            "delete mark data not available as expected",
+        ))
     }
 }

--- a/src/query/storages/fuse/src/io/read/delete/delete_mark_reader_async.rs
+++ b/src/query/storages/fuse/src/io/read/delete/delete_mark_reader_async.rs
@@ -1,0 +1,159 @@
+// Copyright 2023 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_arrow::arrow::bitmap::Bitmap;
+use common_arrow::parquet::metadata::ColumnChunkMetaData;
+use common_arrow::parquet::metadata::ColumnDescriptor;
+use common_base::runtime::GlobalIORuntime;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use opendal::Operator;
+use storages_common_cache::CacheKey;
+use storages_common_cache::InMemoryItemCacheReader;
+use storages_common_cache::LoadParams;
+use storages_common_cache::Loader;
+use storages_common_cache_manager::CachedObject;
+use storages_common_cache_manager::DeleteMarkMeta;
+use storages_common_table_meta::meta::DeleteMaskVersion;
+use storages_common_table_meta::meta::Location;
+
+use crate::io::read::delete::delete_mark_reader::deserialize_bitmap;
+use crate::io::read::InRuntime;
+use crate::io::DeleteMarkReader;
+use crate::io::MetaReaders;
+
+type CachedReader = InMemoryItemCacheReader<Bitmap, DeleteMetaLoader>;
+
+#[async_trait::async_trait]
+impl DeleteMarkReader for Location {
+    async fn read_delete_mark(&self, dal: Operator, size: u64) -> Result<Arc<Bitmap>> {
+        let (path, ver) = &self;
+        let mask_version = DeleteMaskVersion::try_from(*ver)?;
+        if matches!(mask_version, DeleteMaskVersion::V0(_)) {
+            let res = load_delete_mark(dal, path, size).await?;
+            Ok(res)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// load delete mark data
+#[tracing::instrument(level = "debug", skip_all)]
+pub async fn load_delete_mark(dal: Operator, path: &str, size: u64) -> Result<Arc<Bitmap>> {
+    // 1. load delete mark meta
+    let delete_mark_meta = load_mark_meta(dal.clone(), path, size).await?;
+    let file_meta = &delete_mark_meta.0;
+    if file_meta.row_groups.len() != 1 {
+        return Err(ErrorCode::StorageOther(format!(
+            "invalid delete mark meta, number of row group should be 1, but found {} row groups",
+            file_meta.row_groups.len()
+        )));
+    }
+
+    // 2. load delete mark data
+    let index_column_chunk_metas = file_meta.row_groups[0].columns();
+    assert_eq!(index_column_chunk_metas.len(), 1);
+    let column_meta = &index_column_chunk_metas[0];
+    let num_rows = column_meta.num_values();
+    let marks = load_delete_mark_data(column_meta, path, &dal, num_rows as usize).await?;
+
+    Ok(marks)
+}
+
+/// read data from cache, or populate cache items if possible
+#[tracing::instrument(level = "debug", skip_all)]
+async fn load_delete_mark_data<'a>(
+    col_chunk_meta: &'a ColumnChunkMetaData,
+    path: &'a str,
+    dal: &'a Operator,
+    num_rows: usize,
+) -> Result<Arc<Bitmap>> {
+    let storage_runtime = GlobalIORuntime::instance();
+    let bytes = {
+        let meta = col_chunk_meta.metadata();
+        let location = path.to_string();
+        let loader = DeleteMetaLoader {
+            num_rows,
+            offset: meta.data_page_offset as u64,
+            len: meta.total_compressed_size as u64,
+            cache_key: location.clone(),
+            operator: dal.clone(),
+            column_descriptor: col_chunk_meta.descriptor().clone(),
+        };
+
+        let cached_reader = CachedReader::new(Bitmap::cache(), loader);
+
+        let param = LoadParams {
+            location,
+            len_hint: None,
+            ver: 0,
+        };
+        async move { cached_reader.read(&param).await }
+    }
+    .execute_in_runtime(&storage_runtime)
+    .await??;
+    Ok(bytes)
+}
+
+/// Loads index meta data
+/// read data from cache, or populate cache items if possible
+#[tracing::instrument(level = "debug", skip_all)]
+async fn load_mark_meta(dal: Operator, path: &str, size: u64) -> Result<Arc<DeleteMarkMeta>> {
+    let path_owned = path.to_owned();
+    async move {
+        let reader = MetaReaders::delete_mark_meta_reader(dal);
+        // Format of FileMetaData is not versioned, version argument is ignored by the underlying reader,
+        // so we just pass a zero to reader
+        let version = 0;
+
+        let load_params = LoadParams {
+            location: path_owned,
+            len_hint: Some(size),
+            ver: version,
+        };
+
+        reader.read(&load_params).await
+    }
+    .execute_in_runtime(&GlobalIORuntime::instance())
+    .await?
+}
+
+pub struct DeleteMetaLoader {
+    pub num_rows: usize,
+    pub offset: u64,
+    pub len: u64,
+    pub cache_key: String,
+    pub operator: Operator,
+    pub column_descriptor: ColumnDescriptor,
+}
+
+#[async_trait::async_trait]
+impl Loader<Bitmap> for DeleteMetaLoader {
+    async fn load(&self, params: &LoadParams) -> Result<Bitmap> {
+        let reader = self.operator.object(&params.location);
+        let bytes = reader
+            .range_read(self.offset..self.offset + self.len)
+            .await?;
+
+        deserialize_bitmap(&bytes, self.num_rows, &self.column_descriptor)
+    }
+
+    fn cache_key(&self, _params: &LoadParams) -> CacheKey {
+        self.cache_key.clone()
+    }
+}

--- a/src/query/storages/fuse/src/io/read/delete/delete_mark_reader_sync.rs
+++ b/src/query/storages/fuse/src/io/read/delete/delete_mark_reader_sync.rs
@@ -16,27 +16,22 @@
 use std::sync::Arc;
 
 use common_arrow::arrow::bitmap::Bitmap;
-use common_arrow::arrow::datatypes::DataType;
-use common_arrow::arrow::datatypes::Field as ArrowField;
-use common_arrow::arrow::io::parquet::read::column_iter_to_arrays;
-use common_arrow::parquet::compression::Compression;
 use common_arrow::parquet::metadata::ColumnChunkMetaData;
-use common_arrow::parquet::read::BasicDecompressor;
-use common_arrow::parquet::read::PageMetaData;
-use common_arrow::parquet::read::PageReader;
 use common_exception::ErrorCode;
 use common_exception::Result;
-use common_expression::types::BooleanType;
-use common_expression::types::ValueType;
-use common_expression::Column;
 use opendal::Operator;
 use storages_common_cache::CacheKey;
+use storages_common_cache::CachedReader;
 use storages_common_cache::LoadParams;
+use storages_common_cache::SyncLoader;
+use storages_common_cache_manager::CachedObject;
 use storages_common_cache_manager::DeleteMarkMeta;
 use storages_common_table_meta::meta::DeleteMaskVersion;
 use storages_common_table_meta::meta::Location;
 
-use crate::io::read::delete::delete_mark_reader::DeleteMetaLoader;
+use crate::io::read::delete::delete_mark_reader::deserialize_bitmap;
+use crate::io::read::delete::delete_mark_reader_async::DeleteMetaLoader;
+use crate::io::MetaReaders;
 
 // TODO 1. code duplication 2. cache
 pub trait DeleteMarkSyncReader {
@@ -99,44 +94,33 @@ fn sync_load_delete_mark_data<'a>(
         column_descriptor: col_chunk_meta.descriptor().clone(),
     };
 
-    // let cached_reader = CachedReader::new(Bitmap::cache(), loader);
+    let cached_reader = CachedReader::new(Bitmap::cache(), loader);
 
     let param = LoadParams {
         location,
         len_hint: None,
         ver: 0,
     };
-    // let bytes = cached_reader.read(&param)?;
-    let bytes = loader.sync_load(&param)?;
-    Ok(Arc::new(bytes))
+    cached_reader.sync_read(&param)
 }
 
 /// Loads index meta data
 /// read data from cache, or populate cache items if possible
 #[tracing::instrument(level = "debug", skip_all)]
 fn sync_load_mark_meta(dal: Operator, path: &str, size: u64) -> Result<Arc<DeleteMarkMeta>> {
-    // TODO cache
-    let object = dal.object(path);
-    let mut reader = object.blocking_range_reader(0..size)?;
+    let path_owned = path.to_owned();
+    let reader = MetaReaders::delete_mark_meta_reader(dal);
+    // Format of FileMetaData is not versioned, version argument is ignored by the underlying reader,
+    // so we just pass a zero to reader
+    let version = 0;
 
-    use common_arrow::parquet::read::read_metadata;
-    let meta = read_metadata(&mut reader).map_err(|err| {
-        ErrorCode::Internal(format!("read file meta failed, {}, {:?}", path, err))
-    })?;
+    let load_params = LoadParams {
+        location: path_owned,
+        len_hint: Some(size),
+        ver: version,
+    };
 
-    Ok(Arc::new(DeleteMarkMeta(meta)))
-}
-
-/// Loads an object from storage
-#[async_trait::async_trait]
-pub trait SyncLoader<T> {
-    /// Loads object of type T, located by [params][LoadParams].
-    fn sync_load(&self, params: &LoadParams) -> Result<T>;
-
-    /// the [CacheKey] returns will be used as the key of cached item.
-    fn cache_key(&self, params: &LoadParams) -> CacheKey {
-        params.location.clone()
-    }
+    reader.sync_read(&load_params)
 }
 
 impl SyncLoader<Bitmap> for DeleteMetaLoader {
@@ -144,49 +128,7 @@ impl SyncLoader<Bitmap> for DeleteMetaLoader {
         let reader = self.operator.object(&params.location);
         let bytes = reader.blocking_range_read(self.offset..self.offset + self.len)?;
 
-        let page_meta_data = PageMetaData {
-            column_start: 0,
-            num_values: self.num_rows as i64,
-            compression: Compression::Uncompressed,
-            descriptor: self.column_descriptor.descriptor.clone(),
-        };
-
-        let page_reader = PageReader::new_with_page_meta(
-            std::io::Cursor::new(bytes), /* we can not use &[u8] as Reader here, lifetime not valid */
-            page_meta_data,
-            Arc::new(|_, _| true),
-            vec![],
-            usize::MAX,
-        );
-
-        let decompressor = BasicDecompressor::new(page_reader, vec![]);
-        let column_type = self.column_descriptor.descriptor.primitive_type.clone();
-        let filed_name = self.column_descriptor.path_in_schema[0].to_owned();
-        let field = ArrowField::new(filed_name, DataType::Boolean, false);
-        let mut array_iter = column_iter_to_arrays(
-            vec![decompressor],
-            vec![&column_type],
-            field,
-            None,
-            self.num_rows,
-        )?;
-        if let Some(array) = array_iter.next() {
-            let array = array?;
-            let col =
-                Column::from_arrow(array.as_ref(), &common_expression::types::DataType::Boolean);
-
-            let bitmap = BooleanType::try_downcast_column(&col).ok_or_else(|| {
-                ErrorCode::Internal(
-                    "unexpected exception: load delete mark raw data as boolean failed",
-                )
-            })?;
-
-            Ok(bitmap)
-        } else {
-            Err(ErrorCode::StorageOther(
-                "delete mark data not available as expected",
-            ))
-        }
+        deserialize_bitmap(&bytes, self.num_rows, &self.column_descriptor)
     }
 
     fn cache_key(&self, _params: &LoadParams) -> CacheKey {

--- a/src/query/storages/fuse/src/io/read/delete/mod.rs
+++ b/src/query/storages/fuse/src/io/read/delete/mod.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 mod delete_mark_reader;
-mod sync_delete_mark_reader;
+mod delete_mark_reader_async;
+mod delete_mark_reader_sync;
 
 pub use delete_mark_reader::DeleteMarkReader;
-pub use sync_delete_mark_reader::DeleteMarkSyncReader;
+pub use delete_mark_reader_sync::DeleteMarkSyncReader;

--- a/src/query/storages/fuse/src/operations/mutation/refactor/mutation_source.rs
+++ b/src/query/storages/fuse/src/operations/mutation/refactor/mutation_source.rs
@@ -56,7 +56,6 @@ use crate::io::TableMetaLocationGenerator;
 use crate::io::UncompressedBuffer;
 use crate::operations::mutation::refactor::Mutation;
 use crate::operations::mutation::refactor::MutationSourceMeta;
-use crate::operations::mutation::MutationPartInfo as NotInReactorModMutationPartInfo;
 use crate::FuseTable;
 use crate::MergeIOReadResult;
 

--- a/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
+++ b/src/query/storages/fuse/src/operations/read/parquet_data_source_reader.rs
@@ -101,11 +101,7 @@ impl SyncSource for ReadParquetDataSource<true> {
                 let mut delete_mark = None;
                 if let Some((location, meta_size)) = &fuse_part.delete_mark {
                     delete_mark = location
-                        .sync_read_delete_mark(
-                            self.block_reader.operator.clone(),
-                            *meta_size,
-                            fuse_part.nums_rows, // TODO is it correct to use part.num_row?
-                        )?
+                        .sync_read_delete_mark(self.block_reader.operator.clone(), *meta_size)?
                         .into();
                 };
 
@@ -183,11 +179,7 @@ impl Processor for ReadParquetDataSource<false> {
                         let delete_mark = if let Some((location, meta_size)) = &part.delete_mark {
                             Some(
                                 location
-                                    .read_delete_mark(
-                                        block_reader.operator.clone(),
-                                        *meta_size,
-                                        part.nums_rows, // TODO is it correct to use part.num_row?
-                                    )
+                                    .read_delete_mark(block_reader.operator.clone(), *meta_size)
                                     .await?,
                             )
                         } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- [refactor: use num_rows of deletion marker meta](https://github.com/zhyass/databend/commit/1e83bdfd5156e66353f24f199b433d3f806600b5)

- [refactor: add cache for sync block mark reader](https://github.com/zhyass/databend/commit/a5c55049b073bfdc51c51efc66509cd6db291096)

Fixes #issue
