### PR TITLE
chore: add defensive checks and rename variables for clarity

### DIFF
--- a/src/query/service/src/interpreters/interpreter_delete.rs
+++ b/src/query/service/src/interpreters/interpreter_delete.rs
@@ -57,7 +57,6 @@ use databend_common_sql::Visibility;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::operations::TruncateMode;
 use databend_common_storages_fuse::FuseTable;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use futures_util::TryStreamExt;
 use log::debug;
@@ -331,9 +330,7 @@ impl DeleteInterpreter {
             merge_meta,
             deduplicated_label: None,
             plan_id: u32::MAX,
-            merged_blocks: vec![],
-            removed_segment_indexes: vec![],
-            removed_statistics: Statistics::default(),
+            recluster_info: None,
         }));
         plan.adjust_plan_id(&mut 0);
         Ok(plan)

--- a/src/query/service/src/interpreters/interpreter_replace.rs
+++ b/src/query/service/src/interpreters/interpreter_replace.rs
@@ -45,7 +45,6 @@ use databend_common_sql::ScalarBinder;
 use databend_common_storage::StageFileInfo;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotAccessor;
 use parking_lot::RwLock;
 
@@ -354,9 +353,7 @@ impl ReplaceInterpreter {
             merge_meta: false,
             deduplicated_label: unsafe { self.ctx.get_settings().get_deduplicate_label()? },
             plan_id: u32::MAX,
-            merged_blocks: vec![],
-            removed_segment_indexes: vec![],
-            removed_statistics: Statistics::default(),
+            recluster_info: None,
         })));
         root.adjust_plan_id(&mut 0);
         Ok((root, purge_info))

--- a/src/query/service/src/interpreters/interpreter_table_optimize.rs
+++ b/src/query/service/src/interpreters/interpreter_table_optimize.rs
@@ -32,11 +32,11 @@ use databend_common_sql::executor::physical_plans::Exchange;
 use databend_common_sql::executor::physical_plans::FragmentKind;
 use databend_common_sql::executor::physical_plans::MutationKind;
 use databend_common_sql::executor::physical_plans::Recluster;
+use databend_common_sql::executor::physical_plans::ReclusterInfoSideCar;
 use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::plans::OptimizeTableAction;
 use databend_common_sql::plans::OptimizeTablePlan;
 use databend_common_storages_factory::NavigationPoint;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 
 use crate::interpreters::Interpreter;
@@ -139,9 +139,7 @@ impl OptimizeTableInterpreter {
             merge_meta,
             deduplicated_label: None,
             plan_id: u32::MAX,
-            merged_blocks: vec![],
-            removed_segment_indexes: vec![],
-            removed_statistics: Statistics::default(),
+            recluster_info: None,
         })))
     }
 
@@ -227,9 +225,11 @@ impl OptimizeTableInterpreter {
                         merge_meta: false,
                         deduplicated_label: None,
                         plan_id: u32::MAX,
-                        merged_blocks: remained_blocks,
-                        removed_segment_indexes,
-                        removed_statistics: removed_segment_summary,
+                        recluster_info: Some(ReclusterInfoSideCar {
+                            merged_blocks: remained_blocks,
+                            removed_segment_indexes,
+                            removed_statistics: removed_segment_summary,
+                        }),
                     }))
                 }
                 ReclusterParts::Compact(parts) => {

--- a/src/query/service/src/interpreters/interpreter_update.rs
+++ b/src/query/service/src/interpreters/interpreter_update.rs
@@ -42,7 +42,6 @@ use databend_common_sql::executor::PhysicalPlan;
 use databend_common_sql::Visibility;
 use databend_common_storages_factory::Table;
 use databend_common_storages_fuse::FuseTable;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::TableSnapshot;
 use log::debug;
 
@@ -302,9 +301,7 @@ impl UpdateInterpreter {
             merge_meta,
             deduplicated_label: unsafe { ctx.get_settings().get_deduplicate_label()? },
             plan_id: u32::MAX,
-            merged_blocks: vec![],
-            removed_segment_indexes: vec![],
-            removed_statistics: Statistics::default(),
+            recluster_info: None,
         }));
         plan.adjust_plan_id(&mut 0);
         Ok(plan)

--- a/src/query/service/src/pipelines/builders/builder_commit.rs
+++ b/src/query/service/src/pipelines/builders/builder_commit.rs
@@ -46,13 +46,17 @@ impl PipelineBuilder {
                 } else {
                     plan.snapshot.segments().to_vec()
                 };
+
+                // extract re-cluster related mutations from physical plan
+                let recluster_info = plan.recluster_info.clone().unwrap_or_default();
+
                 TableMutationAggregator::create(
                     table,
                     self.ctx.clone(),
                     base_segments,
-                    plan.merged_blocks.clone(),
-                    plan.removed_segment_indexes.clone(),
-                    plan.removed_statistics.clone(),
+                    recluster_info.merged_blocks,
+                    recluster_info.removed_segment_indexes,
+                    recluster_info.removed_statistics,
                     plan.mutation_kind,
                 )
             });

--- a/src/query/sql/src/executor/physical_plans/mod.rs
+++ b/src/query/sql/src/executor/physical_plans/mod.rs
@@ -65,6 +65,7 @@ pub use physical_aggregate_partial::AggregatePartial;
 pub use physical_async_func::AsyncFunction;
 pub use physical_cache_scan::CacheScan;
 pub use physical_commit_sink::CommitSink;
+pub use physical_commit_sink::ReclusterInfoSideCar;
 pub use physical_compact_source::CompactSource;
 pub use physical_constant_table_scan::ConstantTableScan;
 pub use physical_copy_into_location::CopyIntoLocation;

--- a/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_commit_sink.rs
@@ -37,6 +37,12 @@ pub struct CommitSink {
     pub deduplicated_label: Option<String>,
 
     // Used for recluster.
+    pub recluster_info: Option<ReclusterInfoSideCar>,
+}
+
+// TODO refine this
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+pub struct ReclusterInfoSideCar {
     pub merged_blocks: Vec<Arc<BlockMeta>>,
     pub removed_segment_indexes: Vec<usize>,
     pub removed_statistics: Statistics,

--- a/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_merge_into.rs
@@ -32,7 +32,6 @@ use databend_common_expression::ROW_ID_COL_NAME;
 use databend_common_functions::BUILTIN_FUNCTIONS;
 use databend_common_meta_app::schema::TableInfo;
 use databend_storages_common_table_meta::meta::Location;
-use databend_storages_common_table_meta::meta::Statistics;
 use databend_storages_common_table_meta::meta::NUM_BLOCK_ID_BITS;
 use databend_storages_common_table_meta::readers::snapshot_reader::TableSnapshotAccessor;
 use itertools::Itertools;
@@ -490,9 +489,7 @@ impl PhysicalPlanBuilder {
             merge_meta: false,
             deduplicated_label: unsafe { settings.get_deduplicate_label()? },
             plan_id: u32::MAX,
-            merged_blocks: vec![],
-            removed_segment_indexes: vec![],
-            removed_statistics: Statistics::default(),
+            recluster_info: None,
         }));
         physical_plan.adjust_plan_id(&mut 0);
         Ok(physical_plan)

--- a/src/query/sql/src/executor/physical_plans/physical_recluster.rs
+++ b/src/query/sql/src/executor/physical_plans/physical_recluster.rs
@@ -20,8 +20,8 @@ use databend_common_catalog::table::TableExt;
 use databend_common_exception::ErrorCode;
 use databend_common_exception::Result;
 use databend_common_meta_app::schema::TableInfo;
-use databend_storages_common_table_meta::meta::Statistics;
 
+use crate::executor::physical_plans::physical_commit_sink::ReclusterInfoSideCar;
 use crate::executor::physical_plans::CommitSink;
 use crate::executor::physical_plans::CompactSource;
 use crate::executor::physical_plans::Exchange;
@@ -126,9 +126,11 @@ impl PhysicalPlanBuilder {
                     merge_meta: false,
                     deduplicated_label: None,
                     plan_id: u32::MAX,
-                    merged_blocks: remained_blocks,
-                    removed_segment_indexes,
-                    removed_statistics: removed_segment_summary,
+                    recluster_info: Some(ReclusterInfoSideCar {
+                        merged_blocks: remained_blocks,
+                        removed_segment_indexes,
+                        removed_statistics: removed_segment_summary,
+                    }),
                 }))
             }
             ReclusterParts::Compact(parts) => {
@@ -160,9 +162,7 @@ impl PhysicalPlanBuilder {
                     merge_meta,
                     deduplicated_label: None,
                     plan_id: u32::MAX,
-                    merged_blocks: vec![],
-                    removed_segment_indexes: vec![],
-                    removed_statistics: Statistics::default(),
+                    recluster_info: None,
                 }))
             }
         };

--- a/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
+++ b/src/query/storages/fuse/src/operations/common/generators/mutation_generator.rs
@@ -101,7 +101,10 @@ impl SnapshotGenerator for MutationGenerator {
                         previous.table_statistics_location(),
                     );
 
-                    if matches!(self.mutation_kind, MutationKind::Compact) {
+                    if matches!(
+                        self.mutation_kind,
+                        MutationKind::Compact | MutationKind::Recluster
+                    ) {
                         // for compaction, a basic but very important verification:
                         // the number of rows should be the same
                         assert_eq!(

--- a/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
+++ b/src/query/storages/fuse/src/operations/common/meta/mutation_log.rs
@@ -39,7 +39,7 @@ pub enum MutationLogEntry {
         format_version: FormatVersion,
         summary: Statistics,
     },
-    AppendBlock {
+    ReclusterAppendBlock {
         block_meta: Arc<BlockMeta>,
     },
     DeletedBlock {

--- a/src/query/storages/fuse/src/operations/common/processors/transform_serialize_block.rs
+++ b/src/query/storages/fuse/src/operations/common/processors/transform_serialize_block.rs
@@ -329,7 +329,7 @@ impl Processor for TransformSerializeBlock {
                     }
 
                     if matches!(self.kind, MutationKind::Recluster) {
-                        Self::mutation_logs(MutationLogEntry::AppendBlock {
+                        Self::mutation_logs(MutationLogEntry::ReclusterAppendBlock {
                             block_meta: Arc::new(block_meta),
                         })
                     } else {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://databend.rs/dev/policies/cla/

## Summary

- chore: defensive check in snapshot gen for recluster
- chore: rename things to clarify that re-cluster related things are being carried around


