### PR TITLE
refactor: use variant column to unify the schema

### DIFF
--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0008_fuse_optimize_table.test
@@ -572,14 +572,14 @@ insert into t10 values(2),(5),(-7)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t10')
 ----
-(abs(a)) linear 4 1 2.0 2.75 {"00002":1,"00003":3}
+(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"total_block_count":4}
 
 # recluster the unclustered block.
 statement ok
 alter table t10 recluster
 
 query F
-select average_depth from clustering_information('db_09_0008','t10')
+select info:average_depth from clustering_information('db_09_0008','t10')
 ----
 2.75
 
@@ -590,13 +590,13 @@ optimize table t10 compact
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t10')
 ----
-(abs(a)) linear 3 0 2.0 3.0 {"00003":3}
+(abs(a)) linear {"average_depth":3.0,"average_overlaps":2.0,"block_depth_histogram":{"00003":3},"constant_block_count":0,"total_block_count":3}
 
 statement ok
 alter table t10 recluster
 
 query F
-select average_depth from clustering_information('db_09_0008','t10')
+select info:average_depth from clustering_information('db_09_0008','t10')
 ----
 1.0
 
@@ -634,13 +634,13 @@ insert into t11 values(-6),(-8)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t11')
 ----
-(abs(a)) linear 4 1 2.0 2.75 {"00002":1,"00003":3}
+(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"total_block_count":4}
 
 statement ok
 optimize table t11 compact limit 2
 
 query B
-select average_depth > 1.0 from clustering_information('db_09_0008','t11')
+select info:average_depth > 1.0 from clustering_information('db_09_0008','t11')
 ----
 1
 
@@ -796,7 +796,7 @@ alter table t14 recluster
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t14')
 ----
-(a, b) linear 1 0 0.0 1.0 {"00001":1}
+(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":1},"constant_block_count":0,"total_block_count":1}
 
 
 statement ok
@@ -820,7 +820,7 @@ insert into t15 values(2),(5),(-7)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t15')
 ----
-(abs(a)) linear 4 1 2.0 2.75 {"00002":1,"00003":3}
+(abs(a)) linear {"average_depth":2.75,"average_overlaps":2.0,"block_depth_histogram":{"00002":1,"00003":3},"constant_block_count":1,"total_block_count":4}
 
 statement ok
 alter table t15 recluster
@@ -828,13 +828,13 @@ alter table t15 recluster
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0008','t15')
 ----
-(abs(a)) linear 3 0 2.0 3.0 {"00003":3}
+(abs(a)) linear {"average_depth":3.0,"average_overlaps":2.0,"block_depth_histogram":{"00003":3},"constant_block_count":0,"total_block_count":3}
 
 statement ok
 alter table t15 recluster
 
 query TTFF
-select cluster_key, type, average_overlaps, average_depth from clustering_information('db_09_0008','t15')
+select cluster_key, type, info:average_overlaps, info:average_depth from clustering_information('db_09_0008','t15')
 ----
 (abs(a)) linear 0.0 1.0
 

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0014_func_clustering_information_function.test
@@ -32,12 +32,12 @@ select min, max, level from clustering_statistics('default','t09_0014') order by
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014')
 ----
-(b, a) linear 3 1 0.6667 1.6667 {"00001":1,"00002":2}
+(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"total_block_count":3}
 
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014', '(a)')
 ----
-(a) linear 3 1 0.6667 1.6667 {"00001":1,"00002":2}
+(a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"total_block_count":3}
 
 statement ok
 ALTER TABLE t09_0014 DROP CLUSTER KEY
@@ -51,7 +51,7 @@ select * from clustering_statistics('default','t09_0014')
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014', '(b, a)')
 ----
-(b, a) linear 3 1 0.6667 1.6667 {"00001":1,"00002":2}
+(b, a) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"total_block_count":3}
 
 statement ok
 drop table t09_0014
@@ -68,22 +68,22 @@ insert into t09_0014_1 values ('xyy'), ('xyz')
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(c)')
 ----
-(c) linear 2 0 0.0 1.0 {"00001":2}
+(c) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"total_block_count":2}
 
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,1))')
 ----
-(SUBSTRING(c FROM 1)) linear 2 0 0.0 1.0 {"00001":2}
+(SUBSTRING(c FROM 1)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"total_block_count":2}
 
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,1,2))')
 ----
-(SUBSTRING(c FROM 1 FOR 2)) linear 2 2 0.0 1.0 {"00001":2}
+(SUBSTRING(c FROM 1 FOR 2)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":2,"total_block_count":2}
 
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_1', '(substr(c,2,2))')
 ----
-(SUBSTRING(c FROM 2 FOR 2)) linear 2 0 1.0 2.0 {"00002":2}
+(SUBSTRING(c FROM 2 FOR 2)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"total_block_count":2}
 
 statement ok
 drop table t09_0014_1 all
@@ -101,12 +101,12 @@ insert into t09_0014_2 values('bcdff'),('cdefg')
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_2')
 ----
-(SUBSTRING(c FROM 1 FOR 4)) linear 2 0 0.0 1.0 {"00001":2}
+(SUBSTRING(c FROM 1 FOR 4)) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"total_block_count":2}
 
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('default','t09_0014_2', 'substr(c,2,4)')
 ----
-(SUBSTRING(c FROM 2 FOR 4)) linear 2 0 1.0 2.0 {"00002":2}
+(SUBSTRING(c FROM 2 FOR 4)) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"total_block_count":2}
 
 statement ok
 drop table t09_0014_2 all

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0015_remote_alter_cluster_key.test
@@ -22,7 +22,7 @@ INSERT INTO t09_0015_0 VALUES(1,3),(2,1)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(b, a) linear 2 0 1.0 2.0 {"00002":2}
+(b, a) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"total_block_count":2}
 
 statement ok
 ALTER TABLE t09_0015_0 CLUSTER BY(a,b)
@@ -33,7 +33,7 @@ INSERT INTO t09_0015_0 VALUES(4,4)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db1','t09_0015_0')
 ----
-(a, b) linear 3 1 0.6667 1.6667 {"00001":1,"00002":2}
+(a, b) linear {"average_depth":1.6667,"average_overlaps":0.6667,"block_depth_histogram":{"00001":1,"00002":2},"constant_block_count":1,"total_block_count":3}
 
 query II
 SELECT * FROM t09_0015_0 ORDER BY b,a

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0016_remote_alter_recluster.test
@@ -22,7 +22,7 @@ insert into t1 values(4,4)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) linear 3 1 1.3333 2.0 {"00002":3}
+(a + 1) linear {"average_depth":2.0,"average_overlaps":1.3333,"block_depth_histogram":{"00002":3},"constant_block_count":1,"total_block_count":3}
 
 statement ok
 ALTER TABLE t1 RECLUSTER FINAL WHERE a != 4
@@ -30,7 +30,7 @@ ALTER TABLE t1 RECLUSTER FINAL WHERE a != 4
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0016','t1')
 ----
-(a + 1) linear 2 1 1.0 2.0 {"00002":2}
+(a + 1) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":1,"total_block_count":2}
 
 query II
 select * from t1 order by a
@@ -67,7 +67,7 @@ insert into t3 values(1,'a'),(2,null)
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) linear 2 0 1.0 2.0 {"00002":2}
+(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":0,"total_block_count":2}
 
 statement ok
 insert into t3 values(3,'a'),(4,'c')
@@ -76,7 +76,7 @@ statement ok
 ALTER TABLE t3 RECLUSTER
 
 query FFT
-select average_overlaps, average_depth from clustering_information('db_09_0016','t3')
+select info:average_overlaps, info:average_depth from clustering_information('db_09_0016','t3')
 ----
 0.0 1.0
 
@@ -93,7 +93,7 @@ insert into t3 values(3,'123456782'),(4,'123456783')
 query TTIIFFT
 select * exclude(timestamp) from clustering_information('db_09_0016','t3')
 ----
-(b) linear 2 2 1.0 2.0 {"00002":2}
+(b) linear {"average_depth":2.0,"average_overlaps":1.0,"block_depth_histogram":{"00002":2},"constant_block_count":2,"total_block_count":2}
 
 # Fix pr#13332
 statement ok

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0023_replace_into.test
@@ -397,7 +397,7 @@ select a, b FROM test order by a
 query TTIIFFT
 select * exclude(timestamp) FROM clustering_information('db_09_0023','test')
 ----
-(a + 1, b) linear 3 2 0.0 1.0 {"00001":3}
+(a + 1, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":3},"constant_block_count":2,"total_block_count":3}
 
 statement ok
 DROP TABLE test

--- a/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
+++ b/tests/sqllogictests/suites/base/09_fuse_engine/09_0041_auto_compaction.test
@@ -99,7 +99,7 @@ select count() > 4 from fuse_snapshot('i15760', 't1');
 1
 
 query F
-select average_depth from clustering_information('i15760', 't1')
+select info:average_depth from clustering_information('i15760', 't1')
 ----
 1.0
 

--- a/tests/sqllogictests/suites/ee/07_hilbert_clustering/07_0000_recluster_final.test
+++ b/tests/sqllogictests/suites/ee/07_hilbert_clustering/07_0000_recluster_final.test
@@ -41,13 +41,11 @@ select count() from fuse_snapshot('test_hilbert','t');
 ----
 4
 
-statement error 4013
-select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t');
-
 query T
-select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'hilbert');
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t');
 ----
-(a, b) hilbert 4 4 0 0 0 0 4 4
+(a, b) hilbert {"partial_block_count":0,"partial_segment_count":0,"stable_block_count":0,"stable_segment_count":0,"total_block_count":4,"total_segment_count":4,"unclustered_block_count":4,"unclustered_segment_count":4}
+
 
 statement ok
 alter table t recluster final;
@@ -72,9 +70,9 @@ statement ok
 alter table t recluster final;
 
 query T
-select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'hilbert');
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t');
 ----
-(a, b) hilbert 3 5 2 4 1 1 0 0
+(a, b) hilbert {"partial_block_count":1,"partial_segment_count":1,"stable_block_count":4,"stable_segment_count":2,"total_block_count":5,"total_segment_count":3,"unclustered_block_count":0,"unclustered_segment_count":0}
 
 query I
 select count() from fuse_snapshot('test_hilbert','t');
@@ -92,17 +90,74 @@ statement ok
 alter table t cluster by hilbert(b, a);
 
 query T
-select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'hilbert');
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t');
 ----
-(b, a) hilbert 3 5 0 0 0 0 3 5
+(b, a) hilbert {"partial_block_count":0,"partial_segment_count":0,"stable_block_count":0,"stable_segment_count":0,"total_block_count":5,"total_segment_count":3,"unclustered_block_count":5,"unclustered_segment_count":3}
 
 statement ok
 alter table t recluster final;
 
 query T
-select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'hilbert');
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t');
 ----
-(b, a) hilbert 2 5 2 5 0 0 0 0
+(b, a) hilbert {"partial_block_count":0,"partial_segment_count":0,"stable_block_count":5,"stable_segment_count":2,"total_block_count":5,"total_segment_count":2,"unclustered_block_count":0,"unclustered_segment_count":0}
+
+########################################################
+#  force eval as linear clustering by specify columns  #
+########################################################
+
+query T
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'a,b');
+----
+(a, b) linear {"average_depth":1.4,"average_overlaps":0.4,"block_depth_histogram":{"00001":3,"00002":2},"constant_block_count":0,"total_block_count":5}
+
+# column specified not exist
+statement error 1065
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t', 'a,not_exist');
+
+######################
+#  linear clustered  #
+######################
+statement ok
+create or replace table t_linear(a int, b int) cluster by (a, b) row_per_block=2 block_per_segment=2;
+
+# no
+query T
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t_linear');
+----
+(a, b) linear {"average_depth":0.0,"average_overlaps":0.0,"block_depth_histogram":{},"constant_block_count":0,"total_block_count":0}
+
+statement ok
+insert into t_linear values(1, 1), (3, 3);
+
+statement ok
+insert into t_linear values(0, 0), (5, 5);
+
+statement ok
+insert into t_linear values(2, 2), (6, 6);
+
+statement ok
+insert into t_linear values(4, 4), (7, 7);
+
+statement ok
+alter table t_linear recluster final;
+
+query T
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t_linear');
+----
+(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":4},"constant_block_count":0,"total_block_count":4}
+
+#################
+# non-clustered #
+#################
+statement ok
+create or replace table t_none(a int, b int);
+
+statement error 1118.*Unclustered table
+select * EXCLUDE(timestamp) from clustering_information('test_hilbert','t_none');
+
+
+
 
 statement ok
 drop table t all;

--- a/tests/sqllogictests/suites/mode/standalone/ee/explain_hilbert_clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/ee/explain_hilbert_clustering.test
@@ -24,11 +24,10 @@ INSERT INTO test_hilbert VALUES(1, 1), (1, 2);
 statement ok
 INSERT INTO test_hilbert VALUES(2, 1), (2, 2);
 
+# Clustering information after RECLUSTER FINAL will not be checked,
+# since effects of reclustering will be checked by EXPLAINs.
 statement ok
 ALTER TABLE test_hilbert RECLUSTER FINAL;
-
-statement error 4013
-select * from clustering_information('default','test_hilbert')
 
 query T
 EXPLAIN SELECT * FROM test_hilbert WHERE a = 1;

--- a/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
+++ b/tests/sqllogictests/suites/mode/standalone/explain/clustering.test
@@ -16,7 +16,7 @@ ALTER TABLE test_linear RECLUSTER FINAL;
 query TTIIRRT
 select * exclude(timestamp) from clustering_information('default','test_linear')
 ----
-(a, b) linear 2 0 0.0 1.0 {"00001":2}
+(a, b) linear {"average_depth":1.0,"average_overlaps":0.0,"block_depth_histogram":{"00001":2},"constant_block_count":0,"total_block_count":2}
 
 query T
 EXPLAIN SELECT * FROM test_linear WHERE a = 1;

--- a/tests/sqllogictests/suites/query/case_sensitivity/name_hit.test
+++ b/tests/sqllogictests/suites/query/case_sensitivity/name_hit.test
@@ -11,7 +11,7 @@ statement ok
 set sql_dialect = 'mysql'
 
 statement ok
-CREATE TABLE `Student`(id int)
+CREATE OR REPLACE TABLE `Student`(id int)
 
 statement error (?s)1025,.*Unknown table `default`\.`default`\.Student \(unquoted\)\. Did you mean `Student` \(quoted\)\?
 INSERT INTO Student VALUES(1)
@@ -51,7 +51,7 @@ statement ok
 alter table T_17094 cluster by(City)
 
 query TTIIT
-select cluster_key, type, total_block_count, constant_block_count, block_depth_histogram  from clustering_information('default','T_17094')
+select cluster_key, type, info:total_block_count, info:constant_block_count, info:block_depth_histogram  from clustering_information('default','T_17094')
 ----
 (City) linear 0 0 {}
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://docs.databend.com/dev/policies/cla/

## Summary

This PR modifies the `clustering_information` table function to use a `VARIANT` column, enabling a unified schema for both linear and Hilbert clustering.

### Changes
- Added a new `info` column of type `VARIANT` to store clustering details
- Removed all columns except `cluster_key`, `type`, and `timestamp` 
- Reverted the semantics of the optional 3rd argument to its original behavior:
  It specifies cluster keys for evaluation as linear clustering, regardless of whether the table is clustered or the type of clustering applied.


## Tests

- [ ] Unit Test
- [x] Logic Test
- [ ] Benchmark Test
- [ ] No Test - _Explain why_

## Type of change

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that could cause existing functionality not to work as expected)
- [ ] Documentation Update
- [x] Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe):
